### PR TITLE
Restart on change

### DIFF
--- a/pureftpd/init.sls
+++ b/pureftpd/init.sls
@@ -13,3 +13,5 @@ pureftpd_config:
   - name: /etc/pure-ftpd/pure-ftpd.conf
   - source: salt://pureftpd/templates/tmp.tmpl
   - template: jinja
+  - listen_in:
+    - service: {{ pureftpd.service }}

--- a/pureftpd/init.sls
+++ b/pureftpd/init.sls
@@ -6,7 +6,7 @@ pureftpd_install:
   service.running:
     - name: {{ pureftpd.service }}
     - enable: True
-    - reload: True
+    - reload: False
 
 pureftpd_config:
   file.managed:


### PR DESCRIPTION
pure-ftpd is unable to reload, so we'll restart

```
$ systemctl reload pure-ftpd.service
Failed to reload pure-ftpd.service: Job type reload is not applicable for unit pure-ftpd.service.
See system logs and 'systemctl status pure-ftpd.service' for details.
```

